### PR TITLE
[Defect] Fix invalid grant RefreshError in new Gmail API mailer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,12 @@ To get a token for you Pinboard account, see:
 
 
 ## Mailer
-Email is supported using the Gmail API. To set up API credentials and create a token, follow these steps:
-
-- Log into your Gmail account.
-- Create new cloud project: https://console.cloud.google.com/projectcreate
-- Create credentials: https://console.cloud.google.com/apis/credentials
-- Select OAuth Client: [console.cloud.google.com](https://console.cloud.google.com/apis/credentials/oauthclient)
-- Create OAuth Consent Screen: https://console.cloud.google.com/apis/credentials/consent > External
-  - Only external is available to non-workspace users.
-- Create Client:
-  - Type: Desktop App
-- Download JSON file and save to `config` folder as `gmail-api-credential.json`.
-- Enable Service: https://console.developers.google.com/apis/api/gmail.googleapis.com/overview
-
-The first time you run the script, you'll get a link in console to authorize use of your account.
-
-You may also still be able to use the Gmail SMTP mailer if you create an app password:
+Email is supported using the Gmail SMTP with an app password. To set up an app password for your
+Gmail account, see:
 
 - https://support.google.com/accounts/answer/185833
+
+Then update `secrets.py` as detailed above.
 
 
 ## Usage

--- a/config/secrets.py-dist
+++ b/config/secrets.py-dist
@@ -8,7 +8,8 @@ Then reset all TBA values.
 PINBOARD_API_TOKEN = 'TBA'
 
 # Gmail Settings for SMTP Mailer
-# Note: this method has been deprecated. See Mailer Setup section of README.
+# Set up an app password for your Gmail account using docs here:
+# https://support.google.com/accounts/answer/185833
 GMAIL = {
     'address': 'TBA',
     'password': 'TBA'

--- a/mailers/daily_mailer.py
+++ b/mailers/daily_mailer.py
@@ -1,11 +1,11 @@
 from datetime import date
 
-from mailers.gmail_api_mailer import GmailApiMailer
+from mailers.gmail_smtp_mailer import GmailSmtpMailer
 from mailers.helpers import format_bookmark_section
 from services.bookmark_service import distributed_sample, by_created_on_day
 
 
-class DailyMailer(GmailApiMailer):
+class DailyMailer(GmailSmtpMailer):
     def __init__(self):
         subject = 'Pinprick Daily Mailer'
         body = self.compose_body()

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import random
 
 from services.bookmark_service import BookmarkService
 from mailers.daily_mailer import DailyMailer
-from mailers.gmail_api_mailer import GmailApiMailer
+from mailers.gmail_smtp_mailer import GmailSmtpMailer
 
 
 #
@@ -48,7 +48,7 @@ def music_mailer(args):
     bookmarks = BookmarkService.import_by_tags(tags)
     random_bookmarks = random.sample(bookmarks, num_bookmarks)
 
-    mailer = GmailApiMailer(random_bookmarks, subject=subject)
+    mailer = GmailSmtpMailer(random_bookmarks, subject=subject)
     mailer.deliver_to(recipient)
     print('Message delivered to {}'.format(recipient))
 


### PR DESCRIPTION
In my [last PR](https://github.com/klenwell/pinprick/pull/3), I switched Gmail authentication for mailer to API as recommended. However, after a week, I started seeing this error:

```
  File "/home/klenwell/projects/pinprick/mailers/gmail_api_mailer.py", line 35, in refresh_api_credentials
    creds.refresh(Request())
  File "/home/klenwell/pyenv/versions/3.8.1/lib/python3.8/site-packages/google/oauth2/credentials.py", line 302, in refresh
    ) = reauth.refresh_grant(
  File "/home/klenwell/pyenv/versions/3.8.1/lib/python3.8/site-packages/google/oauth2/reauth.py", line 347, in refresh_grant
    _client._handle_error_response(response_data)
  File "/home/klenwell/pyenv/versions/3.8.1/lib/python3.8/site-packages/google/oauth2/_client.py", line 60, in _handle_error_response
    raise exceptions.RefreshError(error_details, response_data)
google.auth.exceptions.RefreshError: ('invalid_grant: Token has been expired or revoked.', {'error': 'invalid_grant', 'error_description': 'Token has been expired or revoked.'})
```

The issue? For test apps (not approved by Google), credentials are only valid for a week. The issue is explained here:

- https://stackoverflow.com/a/66476673/1093087

To fix this, I set up a app password (I had just set one up for Jenkins) and will use that with SMTP mailer.